### PR TITLE
Alterando o redirecionamento para o roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A primeira vez que o deploy for realizado, pode demorar um pouco, a imagem do pr
 ##### Obs: Deploy usando Docker Desktop no Windows requer que acesse o projeto dentro do WSL.
 
 ## Roadmap
-Por favor leia nosso [Roadmap](ROADMAP.md)
+Por favor leia nosso [Roadmap](roadmap.md)
 
 ## Obrigado aos contribuidores ❤
 


### PR DESCRIPTION
Depois que o arquivo com o roadmap foi alterado de texto plano para markdown,  o link para o mesmo, no readme, ficou desatualizado. Algum dos commits alterou isso, mas o nome  do roadmap no link foi escrito em caixa alta, enquanto o nome correto é o que estou adicionando nesse commit (texto normal e minúsculo).