### PR TITLE
Add basic admin auth flow

### DIFF
--- a/app/Http/Controllers/Admin/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Admin/Auth/AuthenticatedSessionController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\Auth\LoginRequest;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+
+class AuthenticatedSessionController extends Controller
+{
+    /**
+     * Handle an incoming authentication request.
+     */
+    public function store(LoginRequest $request): Response
+    {
+        $request->authenticate();
+
+        $request->session()->regenerate();
+
+        return response()->noContent();
+    }
+
+    /**
+     * Destroy an authenticated session.
+     */
+    public function destroy(Request $request): Response
+    {
+        Auth::guard('admin')->logout();
+
+        $request->session()->invalidate();
+
+        $request->session()->regenerateToken();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Admin/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Admin/Auth/NewPasswordController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rules;
+use Illuminate\Validation\ValidationException;
+
+class NewPasswordController extends Controller
+{
+
+    /**
+     * Handle an incoming new password request.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'token' => ['required'],
+            'email' => ['required', 'email'],
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ]);
+
+        // Here we will attempt to reset the user's password. If it is successful we
+        // will update the password on an actual user model and persist it to the
+        // database. Otherwise we will parse the error and return the response.
+        $status = Password::broker('admins')->reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function ($user) use ($request) {
+                $user->forceFill([
+                    'password' => Hash::make($request->password),
+                    'remember_token' => Str::random(60),
+                ])->save();
+
+                event(new PasswordReset($user));
+            }
+        );
+
+        if ($status != Password::PASSWORD_RESET) {
+            throw ValidationException::withMessages([
+                'email' => [__($status)],
+            ]);
+        }
+
+        return response()->json(['status' => __($status)]);
+    }
+}

--- a/app/Http/Controllers/Admin/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Admin/Auth/PasswordResetLinkController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
+
+class PasswordResetLinkController extends Controller
+{
+    /**
+     * Handle an incoming password reset link request.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'email' => ['required', 'email'],
+        ]);
+
+        // We will send the password reset link to this user. Once we have attempted
+        // to send the link, we will examine the response then see the message we
+        // need to show to the user. Finally, we'll send out a proper response.
+        $status = Password::broker('admins')->sendResetLink(
+            $request->only('email')
+        );
+
+        if ($status != Password::RESET_LINK_SENT) {
+            throw ValidationException::withMessages([
+                'email' => [__($status)],
+            ]);
+        }
+
+        return response()->json(['status' => __($status)]);
+    }
+}

--- a/app/Http/Requests/Admin/Auth/LoginRequest.php
+++ b/app/Http/Requests/Admin/Auth/LoginRequest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Requests\Admin\Auth;
+
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class LoginRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * Attempt to authenticate the request's credentials.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function authenticate(): void
+    {
+        $this->ensureIsNotRateLimited();
+
+        if (!Auth::guard('admin')->attempt($this->only('email', 'password'), $this->boolean('remember'))) {
+            RateLimiter::hit($this->throttleKey());
+
+            throw ValidationException::withMessages([
+                'email' => __('auth.failed'),
+            ]);
+        }
+
+        RateLimiter::clear($this->throttleKey());
+    }
+
+    /**
+     * Ensure the login request is not rate limited.
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function ensureIsNotRateLimited(): void
+    {
+        if (!RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+            return;
+        }
+
+        event(new Lockout($this));
+
+        $seconds = RateLimiter::availableIn($this->throttleKey());
+
+        throw ValidationException::withMessages([
+            'email' => trans('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => ceil($seconds / 60),
+            ]),
+        ]);
+    }
+
+    /**
+     * Get the rate limiting throttle key for the request.
+     */
+    public function throttleKey(): string
+    {
+        return Str::transliterate(Str::lower($this->input('email')) . '|' . $this->ip());
+    }
+}

--- a/app/Models/Admin.php
+++ b/app/Models/Admin.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
+
+class Admin extends Authenticatable
+{
+    use HasFactory, HasApiTokens, Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = ['password'];
+
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'admin' => [
+            'driver' => 'session',
+            'provider' => 'admins',
+        ],
     ],
 
     /*
@@ -64,11 +68,10 @@ return [
             'driver' => 'eloquent',
             'model' => App\Models\User::class,
         ],
-
-        // 'users' => [
-        //     'driver' => 'database',
-        //     'table' => 'users',
-        // ],
+        'admins' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Admin::class,
+        ],
     ],
 
     /*
@@ -93,6 +96,12 @@ return [
     'passwords' => [
         'users' => [
             'provider' => 'users',
+            'table' => 'password_reset_tokens',
+            'expire' => 60,
+            'throttle' => 60,
+        ],
+        'admins' => [
+            'provider' => 'admins',
             'table' => 'password_reset_tokens',
             'expire' => 60,
             'throttle' => 60,

--- a/database/factories/AdminFactory.php
+++ b/database/factories/AdminFactory.php
@@ -26,7 +26,6 @@ class AdminFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];

--- a/database/factories/AdminFactory.php
+++ b/database/factories/AdminFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Admin>
+ */
+class AdminFactory extends Factory
+{
+    /**
+     * The current password being used by the factory.
+     */
+    protected static ?string $password;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => static::$password ??= Hash::make('password'),
+            'remember_token' => Str::random(10),
+        ];
+    }
+}

--- a/database/migrations/2024_01_23_212235_create_admins_table.php
+++ b/database/migrations/2024_01_23_212235_create_admins_table.php
@@ -10,7 +10,7 @@ return new class () extends Migration {
      */
     public function up(): void
     {
-        Schema::create('admin', function (Blueprint $table) {
+        Schema::create('admins', function (Blueprint $table) {
             $table->id();
             $table->string('name');
             $table->string('email')->unique();

--- a/database/seeders/AdminsTableSeeder.php
+++ b/database/seeders/AdminsTableSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Admin;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class AdminsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Admin::factory()->create();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,13 +2,7 @@
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
-use App\Enums\UserStatus;
-use App\Enums\UserSupportLevel;
-use App\Models\Admin;
-use App\Models\User;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,27 +11,5 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-
-        /*
-            Test User Seeder.
-        */
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@test.com',
-            'password' => Hash::make('password'),
-            'status' => UserStatus::ACTIVE,
-            'support_level' => UserSupportLevel::HIGH,
-            'report_photo' => 'https://kernel.org/theme/images/logos/tux.png', //placeholder
-            'face_photo' => 'https://kernel.org/theme/images/logos/tux.png', //placeholder
-        ]);
-
-        /*
-            Test Admin Seeder.
-        */
-        Admin::factory()->create([
-            'name' => 'Test Admin',
-            'email' => 'test@test.com',
-            'password' => Hash::make('password'),
-        ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,7 +3,11 @@
 namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Enums\UserStatus;
+use App\Enums\UserSupportLevel;
+use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -12,11 +16,18 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
 
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        /*
+            Test User Seeder.
+        */
+        User::factory()->create([
+            'name' => 'Test User',
+            'email' => 'test@test.com',
+            'password' => Hash::make('password'),
+            'status' => UserStatus::ACTIVE,
+            'support_level' => UserSupportLevel::HIGH,
+            'report_photo' => 'https://kernel.org/theme/images/logos/tux.png', //placeholder
+            'face_photo' => 'https://kernel.org/theme/images/logos/tux.png', //placeholder
+        ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use App\Enums\UserStatus;
 use App\Enums\UserSupportLevel;
+use App\Models\Admin;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
@@ -28,6 +29,15 @@ class DatabaseSeeder extends Seeder
             'support_level' => UserSupportLevel::HIGH,
             'report_photo' => 'https://kernel.org/theme/images/logos/tux.png', //placeholder
             'face_photo' => 'https://kernel.org/theme/images/logos/tux.png', //placeholder
+        ]);
+
+        /*
+            Test Admin Seeder.
+        */
+        Admin::factory()->create([
+            'name' => 'Test Admin',
+            'email' => 'test@test.com',
+            'password' => Hash::make('password'),
         ]);
     }
 }

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        User::factory()->create();
+    }
+}

--- a/routes/admin-auth.php
+++ b/routes/admin-auth.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Admin\Auth\PasswordResetLinkController;
 use Illuminate\Support\Facades\Route;
 
 
-Route::group(['prefix' => 'admin'], function () {
+Route::group(['prefix' => 'admin', 'as' => 'admin.'], function () {
     Route::post('/login', [AuthenticatedSessionController::class, 'store'])
         ->middleware('guest')
         ->name('login');

--- a/routes/admin-auth.php
+++ b/routes/admin-auth.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Http\Controllers\Admin\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\Admin\Auth\NewPasswordController;
+use App\Http\Controllers\Admin\Auth\PasswordResetLinkController;
+use Illuminate\Support\Facades\Route;
+
+
+Route::group(['prefix' => 'admin'], function () {
+    Route::post('/login', [AuthenticatedSessionController::class, 'store'])
+        ->middleware('guest')
+        ->name('login');
+
+    Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
+        ->middleware('guest')
+        ->name('password.email');
+
+    Route::post('/reset-password', [NewPasswordController::class, 'store'])
+        ->middleware('guest')
+        ->name('password.store');
+
+    Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
+        ->middleware('auth:admin')
+        ->name('logout');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,4 +17,6 @@ Route::get('/', function () {
     return ['Laravel' => config('app.version')];
 });
 
-require __DIR__.'/auth.php';
+require __DIR__ . '/auth.php';
+
+require __DIR__ . '/admin-auth.php';

--- a/tests/Feature/Admin/Auth/AuthenticationTest.php
+++ b/tests/Feature/Admin/Auth/AuthenticationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\Admin;
+use App\Models\User;
+use App\Providers\RouteServiceProvider;
+
+test('admins can authenticate using the login screen', function () {
+    $admin = Admin::factory()->create();
+
+    $response = $this->post('/admin/login', [
+        'email' => $admin->email,
+        'password' => 'password',
+    ]);
+
+    $this->assertAuthenticatedAs($admin, guard: 'admin');
+    $response->assertNoContent();
+});
+
+test('admins can not authenticate with invalid password', function () {
+    $user = Admin::factory()->create();
+
+    $this->post('/admin/login', [
+        'email' => $user->email,
+        'password' => 'wrong-password',
+    ]);
+
+    $this->assertGuest(guard: 'admin');
+});
+
+test('normal users cannot access admin routes', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user, guard: 'web')->post('/admin/logout');
+
+    //For now we are getting redirected to home if we try to access protected routes without autorization.
+    $response->assertStatus(302);
+
+    //TODO: This should've been /admin/login for now, but since we are using the same middleware for both admin and user, we are getting redirected to /login.
+    $response->assertRedirect("/login");
+});
+
+test('admins can logout', function () {
+    $admins = Admin::factory()->create();
+
+    $response = $this->actingAs($admins, guard: 'admin')->post('/admin/logout');
+
+    $this->assertGuest();
+    $response->assertNoContent();
+});

--- a/tests/Feature/Admin/Auth/PasswordResetTest.php
+++ b/tests/Feature/Admin/Auth/PasswordResetTest.php
@@ -22,7 +22,7 @@ test('password can be reset with valid token', function () {
     $this->post('/admin/forgot-password', ['email' => $admin->email]);
 
     Notification::assertSentTo($admin, ResetPassword::class, function (object $notification) use ($admin) {
-        $response = $this->post('/reset-password', [
+        $response = $this->post('/admin/reset-password', [
             'token' => $notification->token,
             'email' => $admin->email,
             'password' => 'password',

--- a/tests/Feature/Admin/Auth/PasswordResetTest.php
+++ b/tests/Feature/Admin/Auth/PasswordResetTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Admin;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Notification;
+
+test('reset password link can be requested', function () {
+    Notification::fake();
+
+    $admin = Admin::factory()->create();
+
+    $this->post('/admin/forgot-password', ['email' => $admin->email]);
+
+    Notification::assertSentTo($admin, ResetPassword::class);
+});
+
+test('password can be reset with valid token', function () {
+    Notification::fake();
+
+    $admin = Admin::factory()->create();
+
+    $this->post('/admin/forgot-password', ['email' => $admin->email]);
+
+    Notification::assertSentTo($admin, ResetPassword::class, function (object $notification) use ($admin) {
+        $response = $this->post('/reset-password', [
+            'token' => $notification->token,
+            'email' => $admin->email,
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+
+        return true;
+    });
+});

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,11 +1,17 @@
 <?php
 
+use Illuminate\Http\UploadedFile;
+use App\Enums\UserSupportLevel;
+
 test('new users can register', function () {
     $response = $this->post('/register', [
         'name' => 'Test User',
         'email' => 'test@example.com',
         'password' => 'password',
         'password_confirmation' => 'password',
+        'support_level' => UserSupportLevel::HIGH->value,
+        'report_photo' => UploadedFile::fake()->image('report.png', 600, 600),
+        'face_photo' => UploadedFile::fake()->image('face.png', 600, 600),
     ]);
 
     $this->assertAuthenticated();


### PR DESCRIPTION
1. Added `Admin` model.
2. Set up the admin guard in `config/auth.php`.
3. Duplicated and refactored the generated files to accommodate the new guard and `PasswordBroker`.
4. Added a Admin seeder.